### PR TITLE
Fix Compostion

### DIFF
--- a/lib/src/lottie_builder.dart
+++ b/lib/src/lottie_builder.dart
@@ -303,7 +303,9 @@ class _LottieBuilderState extends State<LottieBuilder> {
 
     if (oldWidget.lottie != widget.lottie) {
       _loadingFuture = widget.lottie.load();
-      _calledLoadedCallback = false;
+      _loadingFuture.then((_) async {
+        _calledLoadedCallback = false;
+      });
     }
   }
 


### PR DESCRIPTION
[Bug] Current animation receive  a`Composition` of pre animation 
I have A and B animations, i want to change from A to B by click to a button and `setState` inside it. After i changed from A to B then B was received a `Composition` of A, continue changed from B to A then A was received a `Composition` of B. Therefore animations  received a wrong `Composition` also `duration` is wrong.
I seen `FutureBuilder` and conditions inside `FutureBuilder` for call `onLoad` callback, i thing it's problem and this pull request can fix it.