### PR TITLE
Sometimes sticker can has a color value stored as RGB, not RGBA

### DIFF
--- a/lib/src/parser/color_parser.dart
+++ b/lib/src/parser/color_parser.dart
@@ -9,7 +9,15 @@ Color colorParser(JsonReader reader, {double scale}) {
   var r = reader.nextDouble();
   var g = reader.nextDouble();
   var b = reader.nextDouble();
-  var a = reader.nextDouble();
+  double a;
+
+  // Sometimes sticker can has a color value stored as RGB, not RGBA
+  if (reader.peek() == Token.number) {
+    a = reader.nextDouble();
+  } else {
+    a = 255;
+  }
+
   if (isArray) {
     reader.endArray();
   }


### PR DESCRIPTION
Affected sticker attached
[sticker.zip](https://github.com/xvrh/lottie-flutter/files/4882815/sticker.zip)

See data at path: layer[0].shape[0].it[2].c.k. It has 3 items, not 4.