### PR TITLE
Fixed doc comments

### DIFF
--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -218,7 +218,6 @@ class Lottie extends StatefulWidget {
 
   /// If no controller is specified, this value indicate whether or not the
   /// Lottie animation should be played automatically (default to true).
-  /// If there is an animation controller specified, this property has no effect.
   ///
   /// See [repeat] to control whether the animation should repeat.
   final bool animate;

--- a/lib/src/lottie_builder.dart
+++ b/lib/src/lottie_builder.dart
@@ -178,7 +178,6 @@ class LottieBuilder extends StatefulWidget {
 
   /// If no controller is specified, this value indicate whether or not the
   /// Lottie animation should be played automatically (default to true).
-  /// If there is an animation controller specified, this property has no effect.
   ///
   /// See [repeat] to control whether the animation should repeat.
   final bool animate;


### PR DESCRIPTION
Fixed doc comments because description for variable `animate` tells: "If there is an animation controller specified, this property has no effect."  and it's not true when it works like that

```
void _updateAutoAnimation() {
    _autoAnimation.stop();
    if (widget.animate && widget.controller == null) {
      if (widget.repeat) {
        _autoAnimation.repeat(reverse: widget.reverse);
      } else {
        _autoAnimation.forward();
      }
    }
  }
```