### PR TITLE
use glyphfonts with text delegate

### DIFF
--- a/lib/src/lottie_drawable.dart
+++ b/lib/src/lottie_drawable.dart
@@ -72,7 +72,7 @@ class LottieDrawable {
   }
 
   bool get useTextGlyphs {
-    return delegates?.text == null && composition.characters.isNotEmpty;
+    return true; // delegates?.text == null && composition.characters.isNotEmpty;
   }
 
   ui.Image getImageAsset(String ref) {

--- a/lib/src/model/layer/text_layer.dart
+++ b/lib/src/model/layer/text_layer.dart
@@ -161,6 +161,10 @@ class TextLayer extends BaseLayer {
     var parentScale = parentMatrix.getScale();
 
     var text = documentData.text;
+    var textDelegate = lottieDrawable.delegates?.text;
+    if (textDelegate != null) {
+      text = textDelegate(text);
+    }
 
     // Line height
     var lineHeight = documentData.lineHeight * window.devicePixelRatio;


### PR DESCRIPTION
Hi, this should maybe be an "issue" but I needed a fix right away for my own uses so this is my little hack fix. Hoping this can open a discussion. Obviously, I don't expect this to PR to be merged as-is.

In my app I'm using glyph fonts to represent numbers. There are several labels some with words and some with numbers. Two labels display a score to the user which needs to be modified at runtime. In our AE file we include numbers 0-9 to enable the use of glyph fonts for this, but for some reason when the text delegate is used glyph fonts are disabled... why?

This simple PR just re-enables it and adds delegate support to the text_layer code. Works perfectly.

Why were glyph fonts disabled when text delegate is used? How can this be changed to provide the user the option to use font text of glyph font (regardless of if the delegate is used)?

For now we're using this forked version to un-break our app, but I'd love to switch back to your package.