### PR TITLE
Add hight filterQuality to solve the problem of unclear display.

### DIFF
--- a/lib/src/model/layer/image_layer.dart
+++ b/lib/src/model/layer/image_layer.dart
@@ -26,6 +26,7 @@ class ImageLayer extends BaseLayer {
     var density = window.devicePixelRatio;
 
     paint.setAlpha(parentAlpha);
+    paint.filterQuality = FilterQuality.high;
     if (_colorFilterAnimation != null) {
       paint.colorFilter = _colorFilterAnimation.value;
     }


### PR DESCRIPTION
When running on large screen devices, such as iPad. The display is not clear, so added "paint.filterQuality = FilterQuality.high" to solve such problems.