### PR TITLE
Support paint on canvas using RenderLottie

### DIFF
--- a/lib/src/render_lottie.dart
+++ b/lib/src/render_lottie.dart
@@ -195,12 +195,16 @@ class RenderLottie extends RenderBox {
   void performLayout() {
     size = _sizeForConstraints(constraints);
   }
-
+  
   @override
   void paint(PaintingContext context, Offset offset) {
+    paintOnCanvas(context.canvas, offset);
+  }
+
+  void paintOnCanvas(Canvas canvas, Offset offset) {
     if (_drawable == null) return;
 
-    _drawable!.draw(context.canvas, offset & size,
+    _drawable!.draw(canvas, offset & size,
         fit: _fit, alignment: _alignment.resolve(TextDirection.ltr));
   }
 

--- a/lib/src/render_lottie.dart
+++ b/lib/src/render_lottie.dart
@@ -195,7 +195,7 @@ class RenderLottie extends RenderBox {
   void performLayout() {
     size = _sizeForConstraints(constraints);
   }
-  
+
   @override
   void paint(PaintingContext context, Offset offset) {
     paintOnCanvas(context.canvas, offset);


### PR DESCRIPTION
# Motivation
I would like to render Lottie via Flame engine. After investigation, it requires the renderer to paint on Canvas directly. You can refer `flame_svg` [as an example](https://github.com/flame-engine/flame/blob/12cf8f70963dc25b4e12182d0c7d80fe7d5a00e0/packages/flame_svg/lib/svg_component.dart#L54). Since `_drawable` in `RenderLottie` is private and Dart does not support internal variables, it cannot be accessed outside. Therefore, the necessary changes are made in the library.

# Implementation Notes
Simply decouple `paint` on `PaintintContext` from `paint` on `Canvas`.
```
  @override
  void paint(PaintingContext context, Offset offset) {
    paintOnCanvas(context.canvas, offset);
  }

  void paintOnCanvas(Canvas canvas, Offset offset) {
    if (_drawable == null) return;

    _drawable!.draw(canvas, offset & size,
        fit: _fit, alignment: _alignment.resolve(TextDirection.ltr));
  }
```