### PR TITLE
Using SetState in initState Fix

### DIFF
--- a/example/lib/examples/animation_full_control.dart
+++ b/example/lib/examples/animation_full_control.dart
@@ -23,15 +23,17 @@ class _MyAppState extends State<MyApp> with TickerProviderStateMixin {
 
   @override
   void initState() {
-    super.initState();
+    _controller = AnimationController(vsync: this);
+    WidgetsBinding.instance.addPostFrameCallback((_) => setState(() {
+          _controller
+            .addListener(() {
+              setState(() {
+                // Rebuild the widget at each frame to update the "progress" label.
+              });
+            });
+        }));
 
-    _controller = AnimationController(vsync: this)
-      ..value = 0.5
-      ..addListener(() {
-        setState(() {
-          // Rebuild the widget at each frame to update the "progress" label.
-        });
-      });
+    super.initState();
   }
 
   @override


### PR DESCRIPTION
Using SetState in initState cause the following error 
```setState() or markNeedsBuild() called when widget tree was locked.```

I have added a `WidgetsBinding.instance.addPostFrameCallback` wrapper to fix it. It's tested and work fine on all platforms.

```
@override
  void initState() {
    _controller = AnimationController(vsync: this);
    WidgetsBinding.instance.addPostFrameCallback((_) => setState(() {
          _controller
            .addListener(() {
              setState(() {
                // Rebuild the widget at each frame to update the "progress" label.
              });
            });
        }));

    super.initState();
  }
```