### PR TITLE
Use AssetLottie in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,7 @@ animation.
 The `Lottie` widget has several convenient constructors (`Lottie.asset`, `Lottie.network`, `Lottie.memory`) to load, parse and
 cache automatically the json file.
 
-Sometime you may prefer to have full control over the loading of the file. Use `LottieComposition.fromByteData` to 
-parse the file from a list of bytes.
+Sometime you may prefer to have full control over the loading of the file. Use `AssetLottie` (or `NetworkLottie`, `MemoryLottie`) to load a lottie composition from a json file.
 
 This example shows how to load and parse a Lottie composition from a json file.  
 

--- a/README.md
+++ b/README.md
@@ -143,14 +143,7 @@ class MyWidget extends StatefulWidget {
 }
 
 class _MyWidgetState extends State<MyWidget> {
-  late final Future<LottieComposition> _composition;
-
-  @override
-  void initState() {
-    super.initState();
-
-    _composition = AssetLottie('assets/LottieLogo1.json').load();
-  }
+  late final Future<LottieComposition> _composition = AssetLottie('assets/LottieLogo1.json').load();
 
   @override
   Widget build(BuildContext context) {

--- a/README.md
+++ b/README.md
@@ -143,7 +143,14 @@ class MyWidget extends StatefulWidget {
 }
 
 class _MyWidgetState extends State<MyWidget> {
-  late final Future<LottieComposition> _composition = AssetLottie('assets/LottieLogo1.json').load();
+  late final Future<LottieComposition> _composition;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _composition = AssetLottie('assets/LottieLogo1.json').load();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/README.md
+++ b/README.md
@@ -149,12 +149,7 @@ class _MyWidgetState extends State<MyWidget> {
   void initState() {
     super.initState();
 
-    _composition = _loadComposition();
-  }
-
-  Future<LottieComposition> _loadComposition() async {
-    var assetData = await rootBundle.load('assets/LottieLogo1.json');
-    return await LottieComposition.fromByteData(assetData);
+    _composition = AssetLottie('assets/LottieLogo1.json').load();
   }
 
   @override

--- a/README.template.md
+++ b/README.template.md
@@ -51,8 +51,7 @@ animation.
 The `Lottie` widget has several convenient constructors (`Lottie.asset`, `Lottie.network`, `Lottie.memory`) to load, parse and
 cache automatically the json file.
 
-Sometime you may prefer to have full control over the loading of the file. Use `LottieComposition.fromByteData` to 
-parse the file from a list of bytes.
+Sometime you may prefer to have full control over the loading of the file. Use `AssetLottie` (or `NetworkLottie`, `MemoryLottie`) to load a lottie composition from a json file.
 
 This example shows how to load and parse a Lottie composition from a json file.  
 

--- a/example/lib/examples/custom_load.dart
+++ b/example/lib/examples/custom_load.dart
@@ -32,12 +32,7 @@ class _MyWidgetState extends State<MyWidget> {
   void initState() {
     super.initState();
 
-    _composition = _loadComposition();
-  }
-
-  Future<LottieComposition> _loadComposition() async {
-    var assetData = await rootBundle.load('assets/LottieLogo1.json');
-    return await LottieComposition.fromByteData(assetData);
+    _composition = AssetLottie('assets/LottieLogo1.json').load();
   }
 
   @override

--- a/example/lib/examples/custom_load.dart
+++ b/example/lib/examples/custom_load.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -150,7 +150,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.0"
+    version: "2.3.0"
   matcher:
     dependency: transitive
     description:


### PR DESCRIPTION
Update documentation to use `AssetLottie(...).load()` instead of `LottieComposition.fromByteData(...)`

Resolves https://github.com/xvrh/lottie-flutter/issues/215