### PR TITLE
Fix rounding-off error on progress calculation

### DIFF
--- a/lib/src/composition.dart
+++ b/lib/src/composition.dart
@@ -173,7 +173,7 @@ class LottieComposition {
     return Duration(milliseconds: (seconds * 1000).round());
   }
 
-  double get seconds => durationFrames / frameRate;
+  double get seconds => (durationFrames + 0.01) / frameRate;
 
   double get startFrame => _parameters.startFrame;
 


### PR DESCRIPTION
I fix a blinking issue when change lottie progress. The duration of compositon has offset in LottieCompositionParser (parameters.endFrame = reader.nextDouble() - 0.01), but progress calculate  is based on the original value(no-offset).

The issue is same as: https://github.com/airbnb/lottie-android/pull/1372.