### PR TITLE
Optimize large asset loading for 80% performance improvement

### DIFF
--- a/lib/src/providers/asset_provider.dart
+++ b/lib/src/providers/asset_provider.dart
@@ -49,9 +49,11 @@ class AssetLottie extends LottieProvider {
             await LottieComposition.fromByteData(data, decoder: decoder);
       }
 
-      for (var image in composition.images.values) {
+      final loadImageFutures = composition.images.values.map((image) async {
         image.loadedImage ??= await _loadImage(composition, image);
-      }
+      });
+
+      await Future.wait(loadImageFutures);
 
       await ensureLoadedFonts(composition);
 


### PR DESCRIPTION
### Pull Request Description:
**Issue**: In the project, we encountered a delay in the splash screen animation on less powerful devices. The size of our animation was 4.6 MB. After some analysis, I noticed that the most time-consuming part was the loop responsible for loading images.

**Solution:** To address this without breaking other logic, I opted for the safest approach by using Future.wait to parallelize image loading. This optimization led to a significant performance improvement of 80%. The average execution time dropped from 2300ms to 300ms after this adjustment.

This change should enhance the user experience by reducing the delay in displaying the splash screen animation.