### PR TITLE
Update archive dependency to fix dart breaking changes

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   flutter: '>=3.16.0'
 
 dependencies:
-  archive: ^3.3.8
+  archive: ^3.6.1
   flutter:
     sdk: flutter
   http: ^1.0.0


### PR DESCRIPTION
In dart 3.4 or higher version, UnmodifiableUint8ListView is deprecated, that is a breaking change. If we use a newer version flutter(that use dart 3.4 or above ), use this pacakge will throw errors:
```
../../.pub-cache/hosted/pub.dev/archive-3.4.10/lib/src/bzip2/bzip2.dart:5:7: Error: Method not found: 'UnmodifiableUint8ListView'.
      UnmodifiableUint8ListView(Uint8List(0));
      ^^^^^^^^^^^^^^^^^^^^^^^^^
../../.pub-cache/hosted/pub.dev/archive-3.4.10/lib/src/bzip2/bzip2.dart:7:7: Error: Method not found: 'UnmodifiableUint32ListView'.
      UnmodifiableUint32ListView(Uint32List(0));
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.pub-cache/hosted/pub.dev/archive-3.4.10/lib/src/bzip2/bzip2.dart:9:7: Error: Method not found: 'UnmodifiableInt32ListView'.
      UnmodifiableInt32ListView(Int32List(0));
      ^^^^^^^^^^^^^^^^^^^^^^^^^
```

relevant topics: 
https://github.com/dart-lang/sdk/issues/53785
https://github.com/jonataslaw/get_cli/issues/263#issuecomment-2273260052
