### PR TITLE
fix: wrap parameters.startFrame between brackets in assert message

### DIFF
--- a/lib/src/parser/lottie_composition_parser.dart
+++ b/lib/src/parser/lottie_composition_parser.dart
@@ -70,7 +70,7 @@ class LottieCompositionParser {
       }
     }
     assert(parameters.startFrame != parameters.endFrame,
-        'startFrame == endFrame ($parameters.startFrame)');
+        'startFrame == endFrame (${parameters.startFrame})');
     assert(
         parameters.frameRate > 0, 'invalid framerate: ${parameters.frameRate}');
 


### PR DESCRIPTION
Brackets were missing around parameters.startFrame so only parameters was print in case the assert failed