### PR TITLE
Fix: normalize absolute image paths in composition loading

### DIFF
--- a/lib/src/composition.dart
+++ b/lib/src/composition.dart
@@ -83,6 +83,9 @@ class LottieComposition {
 
       for (var image in composition.images.values) {
         var imagePath = p.posix.join(image.dirName, image.fileName);
+        if (p.posix.isAbsolute(imagePath)) {
+          imagePath = imagePath.substring(1);
+        }
         var found = archive.files.firstWhereOrNull(
           (f) => f.name.toLowerCase() == imagePath.toLowerCase(),
         );


### PR DESCRIPTION
This PR fixes an issue where image paths inside the composition could start with a leading slash (/), causing them not to match entries in the archive.

```
Expected: images/bg.png  
Got:      /images/bg.png
```

As a result, the image wasn’t found and failed to load.

We now check if the joined path is absolute using p.posix.isAbsolute(imagePath) and remove the leading slash when needed:

```
if (p.posix.isAbsolute(imagePath)) {
  imagePath = imagePath.substring(1);
}
```