### PR TITLE
fix: corrected FileLottie.hashCode to prevent cache memory leak

### DIFF
--- a/lib/src/providers/file_provider_io.dart
+++ b/lib/src/providers/file_provider_io.dart
@@ -69,7 +69,7 @@ class FileLottie extends LottieProvider {
   }
 
   @override
-  int get hashCode => file.hashCode;
+  int get hashCode => file.path.hashCode;
 
   @override
   String toString() => '$runtimeType(file: ${file.path})';


### PR DESCRIPTION
From issue #412: 
## Problem

`FileLottie.operator==` compared `file.path`, but `hashCode` returned
`file.hashCode` (the identity hash of the `io.File` object). This violated
the `hashCode`/`==` contract: two `FileLottie` instances pointing to the
same path were considered equal but produced different hash codes.

As a result, `sharedLottieCache.putIfAbsent(this, ...)` always missed on
a hash lookup, inserting a new cache entry every time the same file was
loaded. Over time this caused the cache to grow without bound, leaking
memory.

## Fix

Change `hashCode` to use `file.path.hashCode` so it is consistent with
the equality comparison.

```dart
// before
int get hashCode => file.hashCode;

// after
int get hashCode => file.path.hashCode;