### PR TITLE
feat: Lottie animation renders at composition frame rate, reducing unnecessary load

### DIFF
--- a/lib/lottie.dart
+++ b/lib/lottie.dart
@@ -1,3 +1,4 @@
+export 'src/lottie_controller.dart' show LottieController;
 export 'src/composition.dart' show LottieComposition, LottieDecoder;
 export 'src/frame_rate.dart' show FrameRate;
 export 'src/lottie.dart' show Lottie;

--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 import 'package:flutter/widgets.dart';
 import 'package:http/http.dart' as http;
@@ -387,74 +388,243 @@ class Lottie extends StatefulWidget {
 }
 
 class _LottieState extends State<Lottie> with TickerProviderStateMixin {
-  late AnimationController _autoAnimation;
+  AnimationController? _autoAnimation;
+  Timer? _timer;
+  double _progress = 0.0;
+  double _lastRenderedProgress = -1.0;
+
+  /// Returns true if the current controller is an external [AnimationController]
+  /// (not a [LottieController]), in which case we use the traditional Ticker drive.
+  bool get _isExternalAnimationController {
+    final controller = widget.controller;
+    return controller != null && controller is! LottieController;
+  }
+
+  bool get _isLottieController {
+    final isLottie = widget.controller is LottieController;
+    return isLottie;
+  }
 
   @override
   void initState() {
     super.initState();
+    _initAnimation();
+  }
 
-    _autoAnimation = AnimationController(
-      vsync: this,
-      duration: widget.composition?.duration ?? const Duration(seconds: 1),
-    );
-    _updateAutoAnimation();
+  void _initAnimation() {
+    if (_isExternalAnimationController) {
+      // External AnimationController: use traditional Ticker drive
+      _autoAnimation?.dispose();
+      _autoAnimation = AnimationController(
+        vsync: this,
+        duration: widget.composition?.duration ?? const Duration(seconds: 1),
+      );
+      _updateAutoAnimation();
+    } else {
+      // No external controller or LottieController: use Timer drive
+      _startTimer();
+    }
+  }
+
+  bool _isReversing = false;
+
+  void _startTimer() {
+    _timer?.cancel();
+    _autoAnimation?.dispose();
+    _autoAnimation = null;
+    widget.controller?.removeListener(_onLottieControllerChanged);
+    _lastRenderedProgress = -1.0;
+    _progress = 0.0;
+
+    final fps = _targetFps;
+    final interval = Duration(microseconds: (1000000 / fps).round());
+    final durationMs = widget.composition?.duration.inMilliseconds ?? 1000;
+    final durationSeconds = durationMs / 1000.0;
+    final step = 1.0 / (fps * (durationSeconds > 0 ? durationSeconds : 1.0));
+
+    if (widget.controller != null && _isLottieController) {
+      // LottieController: sync targetFps and listen to external controller
+      final lottieController = widget.controller! as LottieController;
+      if (widget.animate) {
+        lottieController.targetFps = _targetFps;
+        widget.controller!.addListener(_onLottieControllerChanged);
+      }
+      _progress = widget.controller!.value;
+      return;
+    }
+
+    _timer = Timer.periodic(interval, (timer) {
+      if (!mounted) {
+        timer.cancel();
+        return;
+      }
+      if (!widget.animate) return;
+
+      final controller = widget.controller;
+      if (controller != null) {
+        // External non-LottieController: read its value (frequency mismatch warning)
+        _progress = controller.value;
+      } else {
+        if (_isReversing) {
+          _progress -= step;
+          if (_progress <= 0.0) {
+            _progress = 0.0;
+            if (widget.repeat) {
+              if (widget.reverse) {
+                _isReversing = false;
+              } else {
+                _progress = 0.0;
+              }
+            } else {
+              _timer?.cancel();
+            }
+          }
+        } else {
+          _progress += step;
+          if (_progress >= 1.0) {
+            _progress = 1.0;
+            if (widget.repeat) {
+              if (widget.reverse) {
+                _isReversing = true;
+              } else {
+                _progress = 0.0;
+              }
+            } else {
+              _timer?.cancel();
+            }
+          }
+        }
+      }
+
+      if ((_progress - _lastRenderedProgress).abs() < 0.0001) {
+        return;
+      }
+
+      _lastRenderedProgress = _progress;
+
+      if (mounted) {
+        setState(() {});
+      }
+    });
+  }
+
+  void _onLottieControllerChanged() {
+    if (!mounted) return;
+    final controller = widget.controller;
+    if (controller == null) return;
+    _progress = controller.value;
+    if ((_progress - _lastRenderedProgress).abs() >= 0.0001) {
+      _lastRenderedProgress = _progress;
+      setState(() {});
+    }
+  }
+
+  void _updateAutoAnimation() {
+    _autoAnimation?.stop();
+
+    if (widget.animate && widget.controller == null && _autoAnimation != null) {
+      if (widget.repeat) {
+        _autoAnimation!.repeat(reverse: widget.reverse);
+      } else {
+        _autoAnimation!.forward();
+      }
+    }
+  }
+
+  int get _targetFps {
+    if (widget.frameRate == FrameRate.max) return 60;
+    if (widget.frameRate == FrameRate.composition) {
+      return (widget.composition?.frameRate ?? 30).round();
+    }
+    return (widget.frameRate?.framesPerSecond ??
+            widget.composition?.frameRate ??
+            30)
+        .round();
   }
 
   @override
   void didUpdateWidget(Lottie oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    _autoAnimation.duration =
-        widget.composition?.duration ?? const Duration(seconds: 1);
-    _updateAutoAnimation();
-  }
-
-  void _updateAutoAnimation() {
-    _autoAnimation.stop();
-
-    if (widget.animate && widget.controller == null) {
-      if (widget.repeat) {
-        _autoAnimation.repeat(reverse: widget.reverse);
-      } else {
-        _autoAnimation.forward();
+    if (oldWidget.composition != widget.composition ||
+        oldWidget.frameRate != widget.frameRate ||
+        oldWidget.controller != widget.controller ||
+        oldWidget.animate != widget.animate ||
+        oldWidget.repeat != widget.repeat ||
+        oldWidget.reverse != widget.reverse) {
+      _timer?.cancel();
+      _timer = null;
+      _autoAnimation?.dispose();
+      _autoAnimation = null;
+      if (oldWidget.controller != widget.controller) {
+        oldWidget.controller?.removeListener(_onLottieControllerChanged);
       }
+      // Preserve _isReversing state unless reverse property changed
+      if (oldWidget.reverse != widget.reverse) {
+        _isReversing = false;
+      }
+      _initAnimation();
+    } else {
+      _autoAnimation?.duration =
+          widget.composition?.duration ?? const Duration(seconds: 1);
+      _updateAutoAnimation();
     }
   }
 
   @override
   void dispose() {
-    _autoAnimation.dispose();
+    _timer?.cancel();
+    _timer = null;
+    _autoAnimation?.dispose();
+    _autoAnimation = null;
+    widget.controller?.removeListener(_onLottieControllerChanged);
     super.dispose();
   }
 
   Animation<double> get _progressAnimation =>
-      widget.controller ?? _autoAnimation;
+      widget.controller ?? _autoAnimation ?? const AlwaysStoppedAnimation(0.0);
 
   @override
   Widget build(BuildContext context) {
-    Widget child = AnimatedBuilder(
-      animation: _progressAnimation,
-      builder: (context, _) {
-        return RawLottie(
-          composition: widget.composition,
-          delegates: widget.delegates,
-          options: widget.options,
-          progress: _progressAnimation.value,
-          frameRate: widget.frameRate,
-          width: widget.width,
-          height: widget.height,
-          fit: widget.fit,
-          alignment: widget.alignment,
-          filterQuality: widget.filterQuality,
-          renderCache: widget.renderCache,
-        );
-      },
-    );
+    if (_isExternalAnimationController) {
+      // External AnimationController: AnimatedBuilder listens to AnimationController
+      Widget child = AnimatedBuilder(
+        animation: _progressAnimation,
+        builder: (context, _) {
+          return _buildRawLottie(_progressAnimation.value);
+        },
+      );
+
+      if (widget.addRepaintBoundary) {
+        child = RepaintBoundary(child: child);
+      }
+
+      return child;
+    }
+
+    // Timer drive: direct render
+    var child = _buildRawLottie(_progress);
 
     if (widget.addRepaintBoundary) {
       child = RepaintBoundary(child: child);
     }
 
     return child;
+  }
+
+  Widget _buildRawLottie(double progress) {
+    return RawLottie(
+      composition: widget.composition,
+      delegates: widget.delegates,
+      options: widget.options,
+      progress: progress.clamp(0.0, 1.0),
+      frameRate: widget.frameRate,
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit,
+      alignment: widget.alignment,
+      filterQuality: widget.filterQuality,
+      renderCache: widget.renderCache,
+    );
   }
 }

--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -411,6 +411,17 @@ class _LottieState extends State<Lottie> with TickerProviderStateMixin {
     _initAnimation();
   }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Update TickerMode state for LottieController
+    final controller = widget.controller;
+    if (controller is LottieController) {
+      final tickerMode = TickerMode.of(context);
+      controller.setTickerModeEnabled(enabled: tickerMode);
+    }
+  }
+
   void _initAnimation() {
     if (_isExternalAnimationController) {
       // External AnimationController: use traditional Ticker drive
@@ -423,6 +434,11 @@ class _LottieState extends State<Lottie> with TickerProviderStateMixin {
     } else {
       // No external controller or LottieController: use Timer drive
       _startTimer();
+      // Attach lifecycle notifier for LottieController
+      final controller = widget.controller;
+      if (controller is LottieController) {
+        controller.attachLifecycleNotifier();
+      }
     }
   }
 
@@ -577,6 +593,11 @@ class _LottieState extends State<Lottie> with TickerProviderStateMixin {
     _timer = null;
     _autoAnimation?.dispose();
     _autoAnimation = null;
+    // Detach lifecycle notifier for LottieController
+    final controller = widget.controller;
+    if (controller is LottieController) {
+      controller.detachLifecycleNotifier();
+    }
     widget.controller?.removeListener(_onLottieControllerChanged);
     super.dispose();
   }

--- a/lib/src/lottie_controller.dart
+++ b/lib/src/lottie_controller.dart
@@ -1,0 +1,516 @@
+import 'dart:async';
+import 'package:flutter/animation.dart';
+
+/// A custom animation controller that drives animations using [Timer.periodic]
+/// instead of Flutter's Ticker/Vsync mechanism.
+///
+/// This allows precise frame rate control for Lottie animations, which is
+/// particularly useful on LTPO devices (like HarmonyOS) where Vsync intervals
+/// may be unstable.
+///
+/// [LottieController] implements [Animation<double>] and provides an API
+/// compatible with [AnimationController] for most common use cases:
+/// - [forward], [reverse], [stop], [reset]
+/// - [repeat] with min/max/reverse/period/count
+/// - [animateTo] with duration and curve
+/// - [value] getter/setter
+/// - [addListener], [addStatusListener]
+/// - [duration], [isAnimating], [status]
+///
+/// **Limitations compared to [AnimationController]:**
+/// - [fling] and [animateWith] are not supported (requires physics simulation)
+/// - [TickerFuture] is not returned from control methods; use [addStatusListener]
+///   or the [completed] Future getter instead.
+///
+/// Example usage:
+/// ```dart
+/// class _MyWidgetState extends State<MyWidget> {
+///   late final LottieController _controller;
+///
+///   @override
+///   void initState() {
+///     super.initState();
+///     _controller = LottieController()
+///       ..addListener(() => setState(() {}));
+///   }
+///
+///   @override
+///   void dispose() {
+///     _controller.dispose();
+///     super.dispose();
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return Lottie.asset(
+///       'assets/animation.json',
+///       controller: _controller,
+///     );
+///   }
+/// }
+/// ```
+class LottieController extends Animation<double>
+    with
+        AnimationEagerListenerMixin,
+        AnimationLocalListenersMixin,
+        AnimationLocalStatusListenersMixin {
+  /// Creates a [LottieController].
+  ///
+  /// [value] is the initial progress (0.0 to 1.0).
+  /// [duration] is the total duration of one full animation cycle.
+  /// [reverseDuration] is used when playing in reverse (defaults to [duration]).
+  /// [lowerBound] and [upperBound] clamp the value range (default 0.0 to 1.0).
+  /// [targetFps] controls the Timer tick frequency (default 60).
+  LottieController({
+    double? value,
+    this.duration,
+    this.reverseDuration,
+    this.lowerBound = 0.0,
+    this.upperBound = 1.0,
+    this.debugLabel,
+    int? targetFps,
+  }) : _targetFps = targetFps ?? 60 {
+    assert(lowerBound <= upperBound);
+    if (_targetFps <= 0) {
+      throw ArgumentError('targetFps must be greater than 0');
+    }
+    _internalSetValue(value ?? lowerBound);
+  }
+
+  // ===========================================================================
+  // Public Properties
+  // ===========================================================================
+
+  /// The duration of one full forward animation cycle.
+  Duration? duration;
+
+  /// The duration of one full reverse animation cycle.
+  /// If null, [duration] is used.
+  Duration? reverseDuration;
+
+  /// The minimum value for the animation (default 0.0).
+  final double lowerBound;
+
+  /// The maximum value for the animation (default 1.0).
+  final double upperBound;
+
+  /// A debug label for this controller.
+  final String? debugLabel;
+
+  /// The target frames per second for the Timer tick.
+  int get targetFps => _targetFps;
+  set targetFps(int value) {
+    assert(value > 0);
+    if (_targetFps == value) return;
+    _targetFps = value;
+    // Restart timer if currently running to apply new frequency
+    if (_timer != null && _timer!.isActive) {
+      _timer!.cancel();
+      final now = DateTime.now();
+      if (_startTime != null) {
+        _elapsedAtLastStart += now.difference(_startTime!);
+      }
+      _startTime = now;
+      if (_animateDuration != null) {
+        _timer = Timer.periodic(_tickInterval, _onAnimateTick);
+      } else if (_repeatPeriod != null) {
+        _timer = Timer.periodic(_tickInterval, _onRepeatTick);
+      }
+    }
+  }
+
+  // ===========================================================================
+  // Animation<double> Interface
+  // ===========================================================================
+
+  @override
+  double get value => _value;
+
+  set value(double newValue) {
+    if (_disposed) {
+      throw StateError('Cannot set value on a disposed LottieController');
+    }
+    stop();
+    _internalSetValue(newValue);
+    if (_disposed) return;
+    notifyListeners();
+    _checkStatusChanged();
+  }
+
+  @override
+  AnimationStatus get status => _status;
+
+  @override
+  bool get isAnimating => _isAnimating;
+
+  @override
+  bool get isDismissed => status == AnimationStatus.dismissed;
+
+  @override
+  bool get isCompleted => status == AnimationStatus.completed;
+
+  // ===========================================================================
+  // Control Methods
+  // ===========================================================================
+
+  /// Starts playing the animation forward (from current value to [upperBound]).
+  void forward({double? from}) {
+    _assertNotDisposed();
+    _direction = _AnimationDirection.forward;
+    if (from != null) {
+      _internalSetValue(from);
+    }
+    _animateToInternal(upperBound, duration: duration);
+  }
+
+  /// Starts playing the animation in reverse (from current value to [lowerBound]).
+  void reverse({double? from}) {
+    _assertNotDisposed();
+    _direction = _AnimationDirection.reverse;
+    if (from != null) {
+      _internalSetValue(from);
+    }
+    _animateToInternal(lowerBound, duration: reverseDuration ?? duration);
+  }
+
+  /// Animates to a specific target value with optional duration and curve.
+  void animateTo(
+    double target, {
+    Duration? duration,
+    Curve curve = Curves.linear,
+  }) {
+    _assertNotDisposed();
+    _direction = target >= _value
+        ? _AnimationDirection.forward
+        : _AnimationDirection.reverse;
+    _animateToInternal(
+      target.clamp(lowerBound, upperBound),
+      duration: duration ?? this.duration,
+      curve: curve,
+    );
+  }
+
+  /// Starts a repeating animation.
+  void repeat({
+    double? min,
+    double? max,
+    bool reverse = false,
+    Duration? period,
+    int? count,
+  }) {
+    _assertNotDisposed();
+    if (period == null && duration == null) {
+      throw ArgumentError('Either period or duration must be specified');
+    }
+
+    stop();
+    _repeatMin = (min ?? lowerBound).clamp(lowerBound, upperBound);
+    _repeatMax = (max ?? upperBound).clamp(lowerBound, upperBound);
+    _repeatReverse = reverse;
+    _repeatPeriod = period ?? duration!;
+    _repeatCount = count;
+    _direction = _AnimationDirection.forward;
+
+    if (count != null && count <= 0) {
+      // Nothing to do, reset state to avoid pollution
+      stop();
+      _repeatMin = null;
+      _repeatMax = null;
+      _repeatReverse = false;
+      _repeatPeriod = null;
+      _repeatCount = null;
+      return;
+    }
+
+    _startTimer(_repeatPeriod!, _onRepeatTick);
+  }
+
+  /// Stops the animation at the current value.
+  void stop({bool canceled = true}) {
+    _timer?.cancel();
+    _timer = null;
+    _isAnimating = false;
+
+    if (_completeCompleter != null) {
+      if (!_completeCompleter!.isCompleted) {
+        if (canceled) {
+          _completeCompleter!.completeError(
+            Exception('Animation canceled'),
+            StackTrace.current,
+          );
+        } else {
+          _completeCompleter!.complete();
+        }
+      }
+      _completeCompleter = null;
+    }
+  }
+
+  /// Resets the animation to [lowerBound].
+  void reset() {
+    value = lowerBound;
+  }
+
+  /// Releases resources. The controller must not be used after disposal.
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    stop();
+    clearListeners();
+    clearStatusListeners();
+    super.dispose();
+  }
+
+  // ===========================================================================
+  // Future Support (TickerFuture alternative)
+  // ===========================================================================
+
+  /// A [Future] that completes when the current animation finishes.
+  ///
+  /// **Note:** Each time a new animation is started (via [forward], [reverse],
+  /// [animateTo], or [repeat]), a new completer is created. If you call
+  /// [completed] before starting an animation, the returned Future corresponds
+  /// to the previous animation (if any) and will be completed with an error if
+  /// a new animation is started before the previous one completes.
+  ///
+  /// To wait for a specific animation, call [completed] *after* starting it.
+  ///
+  /// If the animation is not running, returns an already completed Future.
+  Future<void> get completed {
+    if (!_isAnimating) {
+      return Future.value();
+    }
+    _completeCompleter ??= Completer<void>();
+    return _completeCompleter!.future;
+  }
+
+  // ===========================================================================
+  // Internal State
+  // ===========================================================================
+
+  double _value = 0.0;
+  AnimationStatus _status = AnimationStatus.dismissed;
+  Timer? _timer;
+  bool _isAnimating = false;
+  bool _disposed = false;
+  int _targetFps;
+  _AnimationDirection _direction = _AnimationDirection.forward;
+  Completer<void>? _completeCompleter;
+
+  // animateTo state
+  double _startValue = 0.0;
+  double _targetValue = 1.0;
+  Curve _curve = Curves.linear;
+  Duration? _animateDuration;
+  DateTime? _startTime;
+  Duration _elapsedAtLastStart = Duration.zero;
+
+  // repeat state
+  double? _repeatMin;
+  double? _repeatMax;
+  bool _repeatReverse = false;
+  Duration? _repeatPeriod;
+  int? _repeatCount;
+
+  AnimationStatus _lastReportedStatus = AnimationStatus.dismissed;
+
+  // ===========================================================================
+  // Internal Implementation
+  // ===========================================================================
+
+  void _internalSetValue(double newValue) {
+    _value = newValue.clamp(lowerBound, upperBound);
+    if (_value == lowerBound) {
+      _status = AnimationStatus.dismissed;
+    } else if (_value == upperBound) {
+      _status = AnimationStatus.completed;
+    } else {
+      _status = _direction == _AnimationDirection.forward
+          ? AnimationStatus.forward
+          : AnimationStatus.reverse;
+    }
+  }
+
+  void _assertNotDisposed() {
+    if (_disposed) {
+      throw StateError('A $runtimeType was used after being disposed.\n'
+          'Once you have called dispose() on a $runtimeType, it can no longer be used.');
+    }
+  }
+
+  void _animateToInternal(
+    double target, {
+    Duration? duration,
+    Curve curve = Curves.linear,
+  }) {
+    final simulationDuration = duration ?? this.duration;
+    assert(
+      simulationDuration != null,
+      'duration must be set before starting animation',
+    );
+
+    stop();
+    _startValue = _value;
+    _targetValue = target;
+    _curve = curve;
+    _animateDuration = simulationDuration;
+    _startTime = DateTime.now();
+    _elapsedAtLastStart = Duration.zero;
+    _isAnimating = true;
+    _completeCompleter = Completer<void>();
+
+    _timer = Timer.periodic(_tickInterval, _onAnimateTick);
+  }
+
+  Duration get _tickInterval {
+    return Duration(microseconds: (1000000 / _targetFps).round());
+  }
+
+  void _onAnimateTick(Timer timer) {
+    if (_disposed || _timer == null) return;
+    final now = DateTime.now();
+    final elapsed = now.difference(_startTime!) + _elapsedAtLastStart;
+    final totalMs = _animateDuration!.inMilliseconds;
+    final elapsedMs = elapsed.inMilliseconds;
+
+    if (totalMs <= 0) {
+      _internalSetValue(_targetValue);
+      notifyListeners();
+      _checkStatusChanged();
+      _completeAnimation();
+      return;
+    }
+
+    var t = elapsedMs / totalMs;
+
+    // Defensive: t should not exceed 1.0, but use >= for safety
+    if (t >= 1.0) {
+      // Animation complete
+      t = 1.0;
+      _internalSetValue(_targetValue);
+      notifyListeners();
+      _checkStatusChanged();
+      _completeAnimation();
+      return;
+    }
+
+    // Apply curve and compute interpolated value
+    final curvedT = _curve.transform(t);
+    _value = _startValue + (_targetValue - _startValue) * curvedT;
+    _internalSetValue(_value);
+    notifyListeners();
+    _checkStatusChanged();
+  }
+
+  void _onRepeatTick(Timer timer) {
+    if (_disposed || _timer == null) return;
+    final now = DateTime.now();
+    final elapsed = now.difference(_startTime!) + _elapsedAtLastStart;
+    final totalMs = _repeatPeriod!.inMilliseconds;
+    final elapsedMs = elapsed.inMilliseconds;
+
+    if (totalMs <= 0) {
+      _internalSetValue(_repeatMax!);
+      notifyListeners();
+      _checkStatusChanged();
+      _completeAnimation();
+      return;
+    }
+
+    // Compute how many full cycles have elapsed
+    // Use modulo to keep cycles within a reasonable range for performance
+    final cycles = elapsedMs ~/ totalMs;
+    final t = (elapsedMs % totalMs) / totalMs;
+
+    // Check if we've reached the repeat count limit
+    // cycles == 0 means we're in the first cycle
+    if (_repeatCount != null && cycles >= _repeatCount!) {
+      // Finalize at the end position of the last cycle
+      final lastCycleIndex = _repeatCount! - 1;
+      final isReversePhase = _repeatReverse && lastCycleIndex.isOdd;
+      _value = isReversePhase ? _repeatMin! : _repeatMax!;
+      _internalSetValue(_value);
+      notifyListeners();
+      _checkStatusChanged();
+      _completeAnimation();
+      return;
+    }
+
+    // Determine current direction and progress
+    final isReversePhase = _repeatReverse && cycles.isOdd;
+    double progress;
+
+    if (isReversePhase) {
+      progress = 1.0 - t;
+      _direction = _AnimationDirection.reverse;
+    } else {
+      progress = t;
+      _direction = _AnimationDirection.forward;
+    }
+
+    _value = _repeatMin! + (_repeatMax! - _repeatMin!) * progress;
+    _internalSetValue(_value);
+    notifyListeners();
+    _checkStatusChanged();
+  }
+
+  void _startTimer(Duration period, void Function(Timer) callback) {
+    _assertNotDisposed();
+    _timer?.cancel();
+    // Complete any pending completer before starting new animation
+    if (_completeCompleter != null && !_completeCompleter!.isCompleted) {
+      try {
+        _completeCompleter!.completeError(
+          Exception('Animation was restarted before completing'),
+          StackTrace.current,
+        );
+      } catch (e) {
+        // Ignore if already completed
+      }
+    }
+    _completeCompleter = null;
+    _startTime = DateTime.now();
+    _elapsedAtLastStart = Duration.zero;
+    _isAnimating = true;
+    _completeCompleter = Completer<void>();
+    _timer = Timer.periodic(_tickInterval, callback);
+  }
+
+  void _completeAnimation() {
+    _timer?.cancel();
+    _timer = null;
+    _isAnimating = false;
+
+    if (_completeCompleter != null && !_completeCompleter!.isCompleted) {
+      _completeCompleter!.complete();
+      _completeCompleter = null;
+    }
+  }
+
+  void _checkStatusChanged() {
+    final newStatus = status;
+    if (_lastReportedStatus != newStatus) {
+      _lastReportedStatus = newStatus;
+      notifyStatusListeners(newStatus);
+    }
+  }
+
+  // ===========================================================================
+  // Diagnostics
+  // ===========================================================================
+
+  @override
+  String toString() {
+    final buffer = StringBuffer();
+    buffer.write('LottieController(');
+    if (debugLabel != null) buffer.write('"$debugLabel", ');
+    buffer.write('value: ${_value.toStringAsFixed(6)}, ');
+    buffer.write('status: $_status, ');
+    buffer.write('isAnimating: $_isAnimating, ');
+    buffer.write('targetFps: $targetFps)');
+    return buffer.toString();
+  }
+}
+
+enum _AnimationDirection { forward, reverse }

--- a/lib/src/lottie_controller.dart
+++ b/lib/src/lottie_controller.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:flutter/animation.dart';
+import 'package:flutter/widgets.dart';
 
 /// A custom animation controller that drives animations using [Timer.periodic]
 /// instead of Flutter's Ticker/Vsync mechanism.
@@ -16,6 +16,11 @@ import 'package:flutter/animation.dart';
 /// - [value] getter/setter
 /// - [addListener], [addStatusListener]
 /// - [duration], [isAnimating], [status]
+///
+/// **TickerMode and App Lifecycle support:**
+/// - Automatically pauses when [TickerMode] is disabled (e.g., off-screen route)
+/// - Automatically pauses when app goes to background ([AppLifecycleState.paused])
+/// - Automatically resumes when [TickerMode] is re-enabled or app returns to foreground
 ///
 /// **Limitations compared to [AnimationController]:**
 /// - [fling] and [animateWith] are not supported (requires physics simulation)
@@ -141,7 +146,10 @@ class LottieController extends Animation<double>
   AnimationStatus get status => _status;
 
   @override
-  bool get isAnimating => _isAnimating;
+  bool get isAnimating => _isAnimating && _timer != null;
+
+  /// Whether the animation is currently paused (was running but timer is stopped).
+  bool get isPaused => _isAnimating && _timer == null;
 
   @override
   bool get isDismissed => status == AnimationStatus.dismissed;
@@ -230,6 +238,7 @@ class LottieController extends Animation<double>
     _timer?.cancel();
     _timer = null;
     _isAnimating = false;
+    _wasRunningBeforePause = false;
 
     if (_completeCompleter != null) {
       if (!_completeCompleter!.isCompleted) {
@@ -256,6 +265,7 @@ class LottieController extends Animation<double>
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _detachLifecycleNotifier();
     stop();
     clearListeners();
     clearStatusListeners();
@@ -298,6 +308,12 @@ class LottieController extends Animation<double>
   _AnimationDirection _direction = _AnimationDirection.forward;
   Completer<void>? _completeCompleter;
 
+  // TickerMode and App Lifecycle support
+  bool _tickerModeEnabled = true;
+  bool _appIsActive = true;
+  bool _wasRunningBeforePause = false;
+  AppLifecycleListener? _lifecycleListener;
+
   // animateTo state
   double _startValue = 0.0;
   double _targetValue = 1.0;
@@ -314,6 +330,98 @@ class LottieController extends Animation<double>
   int? _repeatCount;
 
   AnimationStatus _lastReportedStatus = AnimationStatus.dismissed;
+
+  // ===========================================================================
+  // TickerMode and App Lifecycle Support
+  // ===========================================================================
+
+  /// Attaches this controller to [TickerMode] and [AppLifecycleState] notifications.
+  ///
+  /// This should be called when the controller is used with a widget that needs
+  /// automatic pause/resume behavior (e.g., when navigating to another route
+  /// or when the app goes to background).
+  ///
+  /// Typically called from [State.didChangeDependencies] or [State.initState].
+  void attachLifecycleNotifier() {
+    _detachLifecycleNotifier();
+
+    // Listen to app lifecycle changes
+    _lifecycleListener = AppLifecycleListener(
+      onStateChange: (state) {
+        _handleAppLifecycleStateChange(state);
+      },
+    );
+  }
+
+  /// Detaches from [TickerMode] and [AppLifecycleState] notifications.
+  void detachLifecycleNotifier() {
+    _detachLifecycleNotifier();
+  }
+
+  void _detachLifecycleNotifier() {
+    _lifecycleListener?.dispose();
+    _lifecycleListener = null;
+  }
+
+  /// Updates the TickerMode enabled state from the widget's build context.
+  /// Called by [Lottie] widget when building.
+  void setTickerModeEnabled({required bool enabled}) {
+    if (_tickerModeEnabled == enabled) return;
+    _tickerModeEnabled = enabled;
+    _handlePauseResume();
+  }
+
+  void _handleAppLifecycleStateChange(AppLifecycleState state) {
+    final isActive = state == AppLifecycleState.resumed ||
+        state == AppLifecycleState.inactive;
+    if (_appIsActive == isActive) return;
+    _appIsActive = isActive;
+    _handlePauseResume();
+  }
+
+  void _handlePauseResume() {
+    final shouldRun = _tickerModeEnabled && _appIsActive;
+    if (shouldRun) {
+      // Should be running
+      if (_wasRunningBeforePause && _timer == null) {
+        // Resume from where we left off (timer is null means we're paused)
+        _resumeAnimation();
+      }
+    } else {
+      // Should pause
+      if (_timer != null) {
+        _wasRunningBeforePause = true;
+        _pauseAnimation();
+      } else {
+        _wasRunningBeforePause = false;
+      }
+    }
+  }
+
+  void _pauseAnimation() {
+    if (_timer == null) return;
+    // Capture elapsed time
+    final now = DateTime.now();
+    if (_startTime != null) {
+      _elapsedAtLastStart += now.difference(_startTime!);
+    }
+    _timer!.cancel();
+    _timer = null;
+    // Note: _isAnimating stays true internally for resume capability,
+    // but isAnimating getter returns false when timer is null
+  }
+
+  void _resumeAnimation() {
+    if (_timer != null) return; // Already running
+    if (!_isAnimating) return; // Not animating, nothing to resume
+
+    _startTime = DateTime.now();
+    if (_animateDuration != null) {
+      _timer = Timer.periodic(_tickInterval, _onAnimateTick);
+    } else if (_repeatPeriod != null) {
+      _timer = Timer.periodic(_tickInterval, _onRepeatTick);
+    }
+  }
 
   // ===========================================================================
   // Internal Implementation


### PR DESCRIPTION

From issue https://github.com/xvrh/lottie-flutter/issues/419
# Lottie animation renders at composition frame rate, reducing unnecessary load

Flutter Ticker forces Lottie animation to synchronize with 60Hz Vsync. Even when the composition's original frame rate (`fr` field) is only 15/30fps, the system still executes the full rendering pipeline at 60Hz, causing unnecessary CPU/GPU load.

This solution adopts Timer drive by default, rendering at the composition's original frame rate or configured `frameRate`, decoupling animation frequency from screen refresh rate to reduce power consumption.

## Key Changes

| Change | Description |
|--------|-------------|
| Default Timer drive | Without external controller / with `LottieController`, render via Timer at configured frame rate |
| Compatible Ticker drive | With external `AnimationController`, automatically uses original Ticker drive |
| New `LottieController` | Same API as `AnimationController`, no `TickerProviderStateMixin` required |
| `frameRate` takes effect | Configuring `FrameRate(30)` or `FrameRate.composition` renders at specified frame rate |

## Usage

```dart
// Default: Timer drive at composition's original frame rate (fr field)
Lottie.asset('assets/animation.json')

// Specify 30fps
Lottie.asset('assets/animation.json', frameRate: FrameRate(30))

// External LottieController
late final LottieController _controller;
```

## Measured Benefits (Android)

**Test Demo:**

```dart
import 'package:flutter/material.dart';
import 'package:lottie/lottie.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: ListView(
          children: [
            // Load a Lottie file from your assets
            Lottie.asset('assets/LottieLogo1.json'),
          ],
        ),
      ),
    );
  }
}
```

**Rendering at fr-specified frame rate from JSON:**

| Metric | Before (Ticker 60Hz) | After (Timer at fr-specified rate) | Reduction |
|--------|---------------------|-----------------------------------|-----------|
| Test 1 | 4,768,733,827 | 2,783,022,888 | 41.6% |
| Test 2 | 4,591,814,457 | 2,975,770,379 | 35.2% |
| Test 3 | 4,765,358,968 | 2,938,497,704 | 38.3% |
| **Average** | **4,708,635,751** | **2,899,097,124** | **38.4%** |

**Average 38.4% reduction in rendering overhead.**

## Backward Compatibility

Existing `AnimationController` code works without modification, automatically uses Ticker drive.
