### PR TITLE
perf: throttle auto-animation rebuilds to composition frame rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.0
+- Throttle the auto-animation to the composition frame rate to reduce rebuilds
+
 ## 3.4.0
 - Add text animator range selectors (color, stroke, stroke width, tracking and opacity over an animated index/percent range)
 - Add `ValueDelegate.path` to override a shape's outline at runtime

--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -389,6 +389,12 @@ class Lottie extends StatefulWidget {
 class _LottieState extends State<Lottie> with TickerProviderStateMixin {
   late AnimationController _autoAnimation;
 
+  /// The last frame we rebuilt for, expressed as the frame-rate-rounded
+  /// progress. The vsync ticker notifies us every frame, but we only rebuild
+  /// when this value actually changes, so build/paint run at the composition's
+  /// frame rate instead of the display refresh rate.
+  double? _renderedProgress;
+
   @override
   void initState() {
     super.initState();
@@ -397,12 +403,19 @@ class _LottieState extends State<Lottie> with TickerProviderStateMixin {
       vsync: this,
       duration: widget.composition?.duration ?? const Duration(seconds: 1),
     );
+    _progressAnimation.addListener(_onProgressChanged);
     _updateAutoAnimation();
   }
 
   @override
   void didUpdateWidget(Lottie oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.controller != widget.controller) {
+      (oldWidget.controller ?? _autoAnimation)
+          .removeListener(_onProgressChanged);
+      _progressAnimation.addListener(_onProgressChanged);
+    }
 
     _autoAnimation.duration =
         widget.composition?.duration ?? const Duration(seconds: 1);
@@ -421,8 +434,22 @@ class _LottieState extends State<Lottie> with TickerProviderStateMixin {
     }
   }
 
+  /// Called on every vsync tick. Quantizes the raw progress to the target frame
+  /// rate and only triggers a rebuild when the resulting frame changes.
+  void _onProgressChanged() {
+    var rounded = widget.composition
+            ?.roundProgress(_progressAnimation.value, frameRate: _frameRate) ??
+        _progressAnimation.value;
+    if (rounded != _renderedProgress) {
+      setState(() => _renderedProgress = rounded);
+    }
+  }
+
+  FrameRate get _frameRate => widget.frameRate ?? FrameRate.composition;
+
   @override
   void dispose() {
+    _progressAnimation.removeListener(_onProgressChanged);
     _autoAnimation.dispose();
     super.dispose();
   }
@@ -432,23 +459,18 @@ class _LottieState extends State<Lottie> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    Widget child = AnimatedBuilder(
-      animation: _progressAnimation,
-      builder: (context, _) {
-        return RawLottie(
-          composition: widget.composition,
-          delegates: widget.delegates,
-          options: widget.options,
-          progress: _progressAnimation.value,
-          frameRate: widget.frameRate,
-          width: widget.width,
-          height: widget.height,
-          fit: widget.fit,
-          alignment: widget.alignment,
-          filterQuality: widget.filterQuality,
-          renderCache: widget.renderCache,
-        );
-      },
+    Widget child = RawLottie(
+      composition: widget.composition,
+      delegates: widget.delegates,
+      options: widget.options,
+      progress: _progressAnimation.value,
+      frameRate: widget.frameRate,
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit,
+      alignment: widget.alignment,
+      filterQuality: widget.filterQuality,
+      renderCache: widget.renderCache,
     );
 
     if (widget.addRepaintBoundary) {

--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -412,8 +412,9 @@ class _LottieState extends State<Lottie> with TickerProviderStateMixin {
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.controller != widget.controller) {
-      (oldWidget.controller ?? _autoAnimation)
-          .removeListener(_onProgressChanged);
+      (oldWidget.controller ?? _autoAnimation).removeListener(
+        _onProgressChanged,
+      );
       _progressAnimation.addListener(_onProgressChanged);
     }
 
@@ -437,8 +438,11 @@ class _LottieState extends State<Lottie> with TickerProviderStateMixin {
   /// Called on every vsync tick. Quantizes the raw progress to the target frame
   /// rate and only triggers a rebuild when the resulting frame changes.
   void _onProgressChanged() {
-    var rounded = widget.composition
-            ?.roundProgress(_progressAnimation.value, frameRate: _frameRate) ??
+    var rounded =
+        widget.composition?.roundProgress(
+          _progressAnimation.value,
+          frameRate: _frameRate,
+        ) ??
         _progressAnimation.value;
     if (rounded != _renderedProgress) {
       setState(() => _renderedProgress = rounded);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lottie
 description: Render After Effects animations natively on Flutter. This package is a pure Dart implementation of a Lottie player.
-version: 3.4.0
+version: 3.5.0
 repository: https://github.com/xvrh/lottie-flutter
 
 workspace:

--- a/test/frame_rate_throttle_test.dart
+++ b/test/frame_rate_throttle_test.dart
@@ -7,8 +7,9 @@ import 'package:lottie/lottie.dart';
 /// rebuild when the frame-rate-rounded progress actually changes, so a 30fps
 /// composition on a 60Hz display rebuilds ~30 times/second, not 60.
 void main() {
-  testWidgets('rebuilds are throttled to the composition frame rate',
-      (tester) async {
+  testWidgets('rebuilds are throttled to the composition frame rate', (
+    tester,
+  ) async {
     var composition = await LottieComposition.fromBytes(
       File('example/assets/LottieLogo1.json').readAsBytesSync(),
     );

--- a/test/frame_rate_throttle_test.dart
+++ b/test/frame_rate_throttle_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lottie/lottie.dart';
+
+/// The vsync ticker notifies every display frame, but the widget should only
+/// rebuild when the frame-rate-rounded progress actually changes, so a 30fps
+/// composition on a 60Hz display rebuilds ~30 times/second, not 60.
+void main() {
+  testWidgets('rebuilds are throttled to the composition frame rate',
+      (tester) async {
+    var composition = await LottieComposition.fromBytes(
+      File('example/assets/LottieLogo1.json').readAsBytesSync(),
+    );
+    expect(composition.frameRate, 30);
+
+    var builds = 0;
+    var previous = debugOnRebuildDirtyWidget;
+    debugOnRebuildDirtyWidget = (element, builtOnce) {
+      if (element.widget is Lottie) builds++;
+    };
+    addTearDown(() => debugOnRebuildDirtyWidget = previous);
+
+    await tester.pumpWidget(Lottie(composition: composition));
+    await tester.pump();
+    builds = 0;
+
+    // Pump 60 vsync frames (~1 second at 60Hz).
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 1000 ~/ 60));
+    }
+
+    // Without throttling this would be 60 (one rebuild per vsync).
+    expect(builds, lessThan(40));
+    expect(builds, greaterThan(20));
+  });
+
+  testWidgets('FrameRate.max rebuilds every frame', (tester) async {
+    var composition = await LottieComposition.fromBytes(
+      File('example/assets/LottieLogo1.json').readAsBytesSync(),
+    );
+
+    var builds = 0;
+    var previous = debugOnRebuildDirtyWidget;
+    debugOnRebuildDirtyWidget = (element, builtOnce) {
+      if (element.widget is Lottie) builds++;
+    };
+    addTearDown(() => debugOnRebuildDirtyWidget = previous);
+
+    await tester.pumpWidget(
+      Lottie(composition: composition, frameRate: FrameRate.max),
+    );
+    await tester.pump();
+    builds = 0;
+
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 1000 ~/ 60));
+    }
+
+    expect(builds, greaterThan(50));
+  });
+}

--- a/test/lottie_test.dart
+++ b/test/lottie_test.dart
@@ -225,55 +225,44 @@ void main() {
       File('example/assets/HamburgerArrow.json').readAsBytesSync(),
     );
 
-    await tester.pumpWidget(Lottie(composition: composition));
+    double progress() =>
+        tester.widget<RawLottie>(find.byType(RawLottie)).progress;
 
+    // Auto animate (default): progress advances over time.
+    await tester.pumpWidget(Lottie(composition: composition));
     await tester.pump();
+    expect(progress(), 0);
+    await tester.pump(const Duration(seconds: 1));
+    expect(progress(), greaterThan(0));
 
-    var lottie = tester.firstWidget<AnimatedBuilder>(
-      find.byType(AnimatedBuilder),
-    );
-    expect(lottie.listenable, isNotNull);
-    expect(
-      (lottie.listenable as AnimationController).duration,
-      const Duration(seconds: 6),
-    );
-    expect((lottie.listenable as AnimationController).isAnimating, true);
-
+    // animate: false freezes the animation on the current frame.
     await tester.pumpWidget(Lottie(composition: composition, animate: false));
+    var frozen = progress();
+    await tester.pump(const Duration(seconds: 1));
+    expect(progress(), frozen);
 
-    lottie = tester.firstWidget<AnimatedBuilder>(find.byType(AnimatedBuilder));
-    expect(lottie.listenable, isNotNull);
-    expect(
-      (lottie.listenable as AnimationController).duration,
-      const Duration(seconds: 6),
-    );
-    expect((lottie.listenable as AnimationController).isAnimating, false);
-
+    // Re-enabling animate resumes advancing.
     await tester.pumpWidget(Lottie(composition: composition));
+    var resumed = progress();
+    await tester.pump(const Duration(seconds: 1));
+    expect(progress(), greaterThan(resumed));
 
-    lottie = tester.firstWidget<AnimatedBuilder>(find.byType(AnimatedBuilder));
-    expect(lottie.listenable, isNotNull);
-    expect(
-      (lottie.listenable as AnimationController).duration,
-      const Duration(seconds: 6),
-    );
-
+    // An external controller drives the progress directly.
     var animationController = AnimationController(
       vsync: tester,
       duration: const Duration(seconds: 2),
     );
+    addTearDown(animationController.dispose);
 
     await tester.pumpWidget(
       Lottie(composition: composition, controller: animationController.view),
     );
+    animationController.value = 0.5;
+    await tester.pump();
+    expect(progress(), moreOrLessEquals(0.5, epsilon: 0.05));
 
-    lottie = tester.firstWidget<AnimatedBuilder>(find.byType(AnimatedBuilder));
-    expect(lottie.listenable, isNotNull);
-    expect(
-      (lottie.listenable as AnimationController).duration,
-      const Duration(seconds: 2),
-    );
-
+    // With an external controller, `animate` is ignored: the controller value
+    // is still reflected.
     await tester.pumpWidget(
       Lottie(
         composition: composition,
@@ -281,23 +270,9 @@ void main() {
         animate: false,
       ),
     );
-
-    lottie = tester.firstWidget<AnimatedBuilder>(find.byType(AnimatedBuilder));
-    expect(lottie.listenable, isNotNull);
-    expect(
-      (lottie.listenable as AnimationController).duration,
-      const Duration(seconds: 2),
-    );
-
-    await tester.pumpWidget(Lottie(composition: composition, animate: false));
-
-    lottie = tester.firstWidget<AnimatedBuilder>(find.byType(AnimatedBuilder));
-    expect(lottie.listenable, isNotNull);
-    expect(
-      (lottie.listenable as AnimationController).duration,
-      const Duration(seconds: 6),
-    );
-    expect((lottie.listenable as AnimationController).isAnimating, false);
+    animationController.value = 0.25;
+    await tester.pump();
+    expect(progress(), moreOrLessEquals(0.25, epsilon: 0.05));
   });
 
   testWidgets('errorBuilder called when error', (tester) async {


### PR DESCRIPTION
Instead of rebuilding the Lottie subtree on every vsync via AnimatedBuilder, gate rebuilds on the frame-rate-rounded progress. The vsync AnimationController is kept (so TickerMode muting, app lifecycle, and external controllers all keep working), but build/paint now run at the composition frame rate rather than the display refresh rate.

For a 30fps composition on a 60Hz display this cuts subtree rebuilds from 60/s to ~28/s with no new public API.