### PR TITLE
Lower minimum required Dart/Flutter SDK back to 3.8.0 / 3.32.0

### DIFF
--- a/lib/src/animation/content/content_group.dart
+++ b/lib/src/animation/content/content_group.dart
@@ -73,8 +73,8 @@ class ContentGroup implements DrawingContent, PathContent, KeyPathElement {
     this.name,
     this._contents,
     AnimatableTransform? transform, {
-    required this._hidden,
-  }) {
+    required bool hidden,
+  }) : _hidden = hidden {
     if (transform != null) {
       _transformAnimation = transform.createAnimation()
         ..addAnimationsToLayer(layer)

--- a/lib/src/render_lottie.dart
+++ b/lib/src/render_lottie.dart
@@ -17,13 +17,13 @@ class RenderLottie extends RenderBox {
     bool? enableApplyingOpacityToLayers,
     double progress = 0.0,
     FrameRate? frameRate,
-    this._width,
-    this._height,
-    this._fit,
-    this._alignment = Alignment.center,
+    double? width,
+    double? height,
+    BoxFit? fit,
+    AlignmentGeometry alignment = Alignment.center,
     FilterQuality? filterQuality,
     RenderCache? renderCache,
-    required this._devicePixelRatio,
+    required double devicePixelRatio,
   }) : assert(progress >= 0.0 && progress <= 1.0),
        assert(
          renderCache == null || frameRate != FrameRate.max,
@@ -39,7 +39,12 @@ class RenderLottie extends RenderBox {
                    enableApplyingOpacityToLayers ?? false
                ..filterQuality = filterQuality)
            : null,
-       _renderCache = renderCache;
+       _width = width,
+       _height = height,
+       _fit = fit,
+       _alignment = alignment,
+       _renderCache = renderCache,
+       _devicePixelRatio = devicePixelRatio;
 
   /// The lottie composition to display.
   LottieComposition? get composition => _drawable?.composition;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
+      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
       url: "https://pub.dev"
     source: hosted
-    version: "100.0.0"
+    version: "93.0.0"
   analyzer:
     dependency: "direct dev"
     description:
       name: analyzer
-      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
+      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "10.0.1"
   archive:
     dependency: "direct main"
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_style
-      sha256: "59d53ef8eaed9d288ed9767618e2b31c4fa0383a127db59d5eb2e737a7638a60"
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.9"
+    version: "3.1.7"
   fake_async:
     dependency: transitive
     description:
@@ -263,10 +263,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -452,10 +452,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -513,5 +513,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  dart: ">=3.10.3 <4.0.0"
+  flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ funding:
   - https://github.com/sponsors/xvrh
 
 environment:
-  sdk: '^3.12.0'
-  flutter: '>=3.44.0'
+  sdk: '^3.8.0'
+  flutter: '>=3.32.0'
 
 dependencies:
   archive: ^4.0.0


### PR DESCRIPTION
This package Dart SDK was recently bumped to `^3.12.0`  in #421.
Version 3.12 was released alongside Flutter 3.44.0 and is quite recent. As a result, **every app that hasn't yet upgraded to the latest stable Flutter is locked out of `lottie` 3.4.0+**, even though nothing in the package actually needs the latest Dart feature introduced in 3.12 (except for a single, small syntactic sugar use case).

This isn't a hypothetical inconvenience or a nitpick: upgrading Flutter in a real production app is often a non-trivial, multi-week effort — other dependencies may not yet support the new SDK and internal QA cycles need to re-run. A rendering library like `lottie` is exactly the kind of dependency that should try to stay as permissive as possible about its minimum SDK.

## What the code actually requires

I inspected the full project to find the _actual_ minimum Dart SDK floor:

- **Language features**: the highest one genuinely used is **null-aware collection elements** from Dart `3.8`. Everything else (records, if-case patterns, switch expressions, `base class`) is available from Dart 3.0.
- **`pub` workspaces**: the `workspace: [example]` field added in #421 needs Dart **3.6** to resolve.
- **Direct dependencies** (`archive ^4.0.0`, `http ^1.0.0`, `path ^1.8.0`, `vector_math ^2.1.0`): none require more than Dart 3.0.0 at their pinned minimum versions.
- **Two constructors used Dart 3.12's private named parameters** (`ContentGroup.copy`, `RenderLottie`) — introduced in #421. This lead to the jump to 3.12: a minor initializer-list convenience in two constructors, whose SDK-floor cost wasn't called out anywhere in that PR.

## What this PR does

- Rewrites the two constructors back to the pre-#421 style (public named parameter + initializer-list assignment) — behaviorally identical.
- Lowers `environment.sdk` to `^3.8.0` and `flutter` to `>=3.32.0`, matching the actual floor (null-aware elements + workspaces) instead of an incidental one.

This restores compatibility for anyone on a Flutter version from the last ~1 year, without giving up anything shipped in 3.4.0/3.5.x.

Minimum SDK bumps have a real, direct cost for every consumer of the package, so it's a good practice to call them out explicitly in the CHANGELOG whenever they happen — as was correctly done for version 3.3.0.