### PR TITLE
Fix time remapping with stretched precompositions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 3.5.1
+- Fix blank frames on pre-compositions using both time remapping and a time stretch
 - Fix cropped fits (e.g. `BoxFit.cover`) ignoring `alignment` and always cropping from the top-left
 - Fix the raster render cache serving the wrong crop when two animations shared a composition and size but differed in fit/alignment
 

--- a/lib/src/model/layer/composition_layer.dart
+++ b/lib/src/model/layer/composition_layer.dart
@@ -144,10 +144,10 @@ class CompositionLayer extends BaseLayer {
 
     if (_timeRemapping == null) {
       progress -= layerModel.startProgress;
-    }
-    //Time stretch needs to be divided if is not "__container"
-    if (layerModel.timeStretch != 0 && layerModel.name != '__container') {
-      progress /= layerModel.timeStretch;
+      // Time remapping already defines the child time directly.
+      if (layerModel.timeStretch != 0 && layerModel.name != '__container') {
+        progress /= layerModel.timeStretch;
+      }
     }
     for (var i = _layers.length - 1; i >= 0; i--) {
       _layers[i].setProgress(progress);

--- a/lib/src/model/layer/composition_layer.dart
+++ b/lib/src/model/layer/composition_layer.dart
@@ -139,12 +139,12 @@ class CompositionLayer extends BaseLayer {
       var remappedFrames =
           _timeRemapping!.value * layerModel.composition.frameRate -
           compositionDelayFrames;
+      // The remapped value is already the child time, so the time stretch is
+      // not applied on top of it. lottie-android does, lottie-web/ios don't.
       progress = remappedFrames / durationFrames;
-    }
-
-    if (_timeRemapping == null) {
+    } else {
       progress -= layerModel.startProgress;
-      // Time remapping already defines the child time directly.
+      //Time stretch needs to be divided if is not "__container"
       if (layerModel.timeStretch != 0 && layerModel.name != '__container') {
         progress /= layerModel.timeStretch;
       }

--- a/test/time_remapping_test.dart
+++ b/test/time_remapping_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+import 'dart:ui';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lottie/lottie.dart';
+
+void main() {
+  test('does not stretch remapped child time', () async {
+    // The remap freezes child frame 50. Stretching that result again would
+    // select frame 25, outside the red layer's [40, 60) visibility range.
+    var pixel = await _renderCenterPixel(includeTimeRemapping: true);
+
+    expect(pixel, const Color(0xffff0000));
+  });
+
+  test('continues to stretch child time without remapping', () async {
+    var pixel = await _renderCenterPixel(includeTimeRemapping: false);
+
+    expect(pixel, const Color(0x00000000));
+  });
+}
+
+Future<Color> _renderCenterPixel({required bool includeTimeRemapping}) async {
+  var timeRemapping = includeTimeRemapping ? '"tm": {"a": 0, "k": 5},' : '';
+  var composition = await LottieComposition.fromBytes(
+    utf8.encode('''
+{
+  "v": "5.7.4",
+  "fr": 10,
+  "ip": 0,
+  "op": 100,
+  "w": 10,
+  "h": 10,
+  "assets": [
+    {
+      "id": "precomp",
+      "layers": [
+        {
+          "ty": 1,
+          "ind": 1,
+          "nm": "Red solid",
+          "sw": 10,
+          "sh": 10,
+          "sc": "#ff0000",
+          "ip": 40,
+          "op": 60,
+          "st": 0,
+          "sr": 1,
+          "ks": {
+            "o": {"a": 0, "k": 100},
+            "r": {"a": 0, "k": 0},
+            "p": {"a": 0, "k": [0, 0, 0]},
+            "a": {"a": 0, "k": [0, 0, 0]},
+            "s": {"a": 0, "k": [100, 100, 100]}
+          }
+        }
+      ]
+    }
+  ],
+  "layers": [
+    {
+      "ty": 0,
+      "ind": 1,
+      "nm": "Stretched precomp",
+      "refId": "precomp",
+      "w": 10,
+      "h": 10,
+      "ip": 0,
+      "op": 100,
+      "st": 0,
+      "sr": 2,
+      $timeRemapping
+      "ks": {
+        "o": {"a": 0, "k": 100},
+        "r": {"a": 0, "k": 0},
+        "p": {"a": 0, "k": [0, 0, 0]},
+        "a": {"a": 0, "k": [0, 0, 0]},
+        "s": {"a": 0, "k": [100, 100, 100]}
+      }
+    }
+  ]
+}
+'''),
+  );
+  var drawable = LottieDrawable(composition)..setProgress(0.5);
+  var recorder = PictureRecorder();
+  var canvas = Canvas(recorder);
+  drawable.draw(canvas, const Rect.fromLTWH(0, 0, 10, 10));
+  var picture = recorder.endRecording();
+  var image = await picture.toImage(10, 10);
+  var pixels = await image.toByteData();
+  var centerOffset = (5 * 10 + 5) * 4;
+  var color = Color.fromARGB(
+    pixels!.getUint8(centerOffset + 3),
+    pixels.getUint8(centerOffset),
+    pixels.getUint8(centerOffset + 1),
+    pixels.getUint8(centerOffset + 2),
+  );
+
+  image.dispose();
+  picture.dispose();
+  return color;
+}


### PR DESCRIPTION
Addresses the reproducible blank-frame case in the original attachment to #323.
The two later reports in that thread do not include equivalent assets, so this
PR does not claim to resolve them.

## Root cause

When a precomposition has time remapping, lottie-flutter converts the remapped
seconds into child-frame progress and then divides that already-remapped result
by the layer's `sr`. In the original animation, this second operation moves the
child outside its visible content and produces blank frames.

Time-remap output already identifies child time.
[lottie-web](https://github.com/airbnb/lottie-web/blob/bede03d25d232826e0c9dca1733d542d8a7754fb/player/js/elements/CompElement.js#L49-L57)
and both Lottie iOS rendering paths
([main-thread](https://github.com/airbnb/lottie-ios/blob/f8ea198bdf6a588739a9256a8196e36106c988b9/Sources/Private/MainThread/LayerContainers/CompLayers/PreCompositionLayer.swift#L114-L121),
[Core Animation](https://github.com/airbnb/lottie-ios/blob/f8ea198bdf6a588739a9256a8196e36106c988b9/Sources/Private/CoreAnimation/Layers/PreCompLayer.swift#L74-L82))
use that output directly and apply start/stretch calculation only when
remapping is absent.

The [Lottie specification](https://lottie.github.io/lottie-spec/latest/specs/layers/#time-remap)
separately says stretch is applied first when both `sr` and `tm` are present.
This PR does not change the input used to sample an animated `tm`; it only
removes the output-side `sr` division.
[Lottie Android](https://github.com/airbnb/lottie-android/blob/05ea92e90381eb8a8ae06855ea2b74f322bebbec/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java#L202-L205)
currently retains that division, so this is an intentional compatibility
difference supported by the original asset and the web/iOS behavior.

## Summary

- apply precomposition time stretch only when time remapping is absent
- treat runtime `ValueDelegate.timeRemap` values as direct child time too,
  without applying the layer stretch to their output
- add a focused pixel regression in which remapping selects child frame 50 and
  the old extra division incorrectly selects frame 25
- retain a no-remap control that guards against accidentally removing ordinary
  time stretch

## Testing

- base plus the new test only: the remapped case failed with a transparent
  pixel instead of red; the no-remap control passed
- `flutter test test/time_remapping_test.dart`: 2 passed
- original issue asset at frame 130:
  - base: 0 non-transparent pixels
  - patched: 167,294 non-transparent pixels
- additional checks passed:
  - `flutter analyze`
  - ten selected non-golden root test files: 464 tests
  - `flutter test` in `example`: 1 test
  - `flutter pub run tool/prepare_submit.dart`
  - `flutter build web` in `example`

The full root `flutter test` run on Windows completed with 990 passed and 30
failed. Every failure was a golden pixel comparison. The tracked golden inputs
with time remapping all have an effective `sr` of 1, so those failures do not
exercise the changed `tm` plus non-unit-`sr` path.

This repository documents golden generation and verification for pinned Apple
Silicon macOS runners. That canonical golden run was not available locally.