### PR TITLE
added clipRect while drawing canvas to fix clip issue on BoxFit.cover

### DIFF
--- a/lib/src/lottie_drawable.dart
+++ b/lib/src/lottie_drawable.dart
@@ -240,8 +240,8 @@ class LottieDrawable {
     }
     if (!cacheUsed) {
       canvas.save();
-      canvas.translate(destinationRect.left, destinationRect.top);
       canvas.clipRect(rect);
+      canvas.translate(destinationRect.left, destinationRect.top);
       _matrix.setSourceToDestinationScale(sourceRect, destinationSize);
       _compositionLayer.draw(canvas, _matrix, parentAlpha: 255);
       canvas.restore();

--- a/lib/src/lottie_drawable.dart
+++ b/lib/src/lottie_drawable.dart
@@ -241,6 +241,7 @@ class LottieDrawable {
     if (!cacheUsed) {
       canvas.save();
       canvas.translate(destinationRect.left, destinationRect.top);
+      canvas.clipRect(rect);
       _matrix.setSourceToDestinationScale(sourceRect, destinationSize);
       _compositionLayer.draw(canvas, _matrix, parentAlpha: 255);
       canvas.restore();

--- a/test/clip_bleed_test.dart
+++ b/test/clip_bleed_test.dart
@@ -25,8 +25,10 @@ void main() {
       final image = await recorder.endRecording().toImage(100, 100);
       final pixels = await image.toByteData();
 
-      final offset = (5 * 100 + 5) * 4;
-      expect(pixels!.getUint8(offset + 3), 0);
+      final insideOffset = (50 * 100 + 50) * 4;
+      expect(pixels!.getUint8(insideOffset + 3), greaterThan(0));
+      final outsideOffset = (5 * 100 + 5) * 4;
+      expect(pixels.getUint8(outsideOffset + 3), 0);
     },
   );
 }

--- a/test/clip_bleed_test.dart
+++ b/test/clip_bleed_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';

--- a/test/clip_bleed_test.dart
+++ b/test/clip_bleed_test.dart
@@ -47,7 +47,7 @@ const _bleedingCompositionJson = {
   'h': 100,
   'nm': 'green_circle',
   'ddd': 0,
-  'assets': [],
+  'assets': <dynamic>[],
   'layers': [
     {
       'ddd': 0,

--- a/test/clip_bleed_test.dart
+++ b/test/clip_bleed_test.dart
@@ -1,0 +1,126 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lottie/lottie.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'draw() clips artwork that bleeds past the composition bounds',
+    () async {
+      final bytes = Uint8List.fromList(
+        utf8.encode(jsonEncode(_bleedingCompositionJson)),
+      );
+      final composition = LottieComposition.parseJsonBytes(bytes);
+      final drawable = LottieDrawable(composition)..setProgress(0);
+      final recorder = ui.PictureRecorder();
+      final canvas = Canvas(recorder);
+      const destRect = Rect.fromLTWH(30, 30, 40, 40);
+
+      drawable.draw(canvas, destRect, fit: BoxFit.cover);
+      final image = await recorder.endRecording().toImage(100, 100);
+      final pixels = await image.toByteData();
+
+      final offset = (5 * 100 + 5) * 4;
+      expect(pixels!.getUint8(offset + 3), 0);
+    },
+  );
+}
+
+// Declared on a 100x100 canvas, but the circle itself has a 600 diameter
+// centered at (50, 50) — it extends far past the composition's own bounds,
+// the way real AE exports often bleed past their frame edges. Without the
+// clipRect fix this paints straight through to pixel (5, 5), well outside
+// destRect.
+const _bleedingCompositionJson = {
+  'v': '5.5.2',
+  'fr': 30,
+  'ip': 0,
+  'op': 30,
+  'w': 100,
+  'h': 100,
+  'nm': 'green_circle',
+  'ddd': 0,
+  'assets': [],
+  'layers': [
+    {
+      'ddd': 0,
+      'ind': 1,
+      'ty': 4,
+      'nm': 'circle_layer',
+      'sr': 1,
+      'ks': {
+        'o': {'a': 0, 'k': 100},
+        'r': {'a': 0, 'k': 0},
+        'p': {
+          'a': 0,
+          'k': [50, 50, 0],
+        },
+        'a': {
+          'a': 0,
+          'k': [0, 0, 0],
+        },
+        's': {
+          'a': 0,
+          'k': [100, 100, 100],
+        },
+      },
+      'ao': 0,
+      'shapes': [
+        {
+          'ty': 'gr',
+          'nm': 'Circle Group',
+          'it': [
+            {
+              'ty': 'el',
+              'nm': 'bleedingCircle',
+              'p': {
+                'a': 0,
+                'k': [0, 0],
+              },
+              's': {
+                'a': 0,
+                'k': [600, 600],
+              },
+            },
+            {
+              'ty': 'fl',
+              'nm': 'greenFill',
+              'c': {
+                'a': 0,
+                'k': [0, 1, 0, 1],
+              },
+              'o': {'a': 0, 'k': 100},
+            },
+            {
+              'ty': 'tr',
+              'nm': 'Transform',
+              'p': {
+                'a': 0,
+                'k': [0, 0],
+              },
+              'a': {
+                'a': 0,
+                'k': [0, 0],
+              },
+              's': {
+                'a': 0,
+                'k': [100, 100],
+              },
+              'r': {'a': 0, 'k': 0},
+              'o': {'a': 0, 'k': 100},
+            },
+          ],
+        },
+      ],
+      'ip': 0,
+      'op': 30,
+      'st': 0,
+      'bm': 0,
+    },
+  ],
+};


### PR DESCRIPTION
### Steps to reproduce


1. Render a Lottie widget (asset/network/memory — reproduces identically regardless of source) whose composition has artwork that extends past its own declared w/h bounds.

2. Constrain the widget to a size/aspect ratio different from the composition's own, with fit: BoxFit.cover.

3. Place another widget directly after it (e.g. in a Column).

### Expected results

<img width="540" height="1200" alt="Image" src="https://github.com/user-attachments/assets/d98b3201-aade-45eb-b43f-ce85cc1a000d" />

The Lottie animation is cropped to exactly the box it was given, same as Image with BoxFit.cover — nothing paints outside that box regardless of what the composition's artwork does internally.

### Actual results

<img width="540" height="1200" alt="Image" src="https://github.com/user-attachments/assets/e3bafbf2-6e26-4528-8d39-469eb2965b3e" />

The overflowing artwork paints past the given box and visually overlaps/underlaps whatever renders next in the tree, as if no clipping were applied at all.

### Code sample

```
 @override
  Widget build(BuildContext context) {
    final double lottieHeight = 200;
    final double aspectRatio = 2.29;
    final double sizedBoxHeight = 50;
    return Scaffold(
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: [
            SizedBox(
              height: sizedBoxHeight,
              child: Lottie.network(
                'https://raw.githubusercontent.com/the-extremity11/assets/main/astronot.json',
                width: lottieHeight * aspectRatio,
                fit: BoxFit.cover,
              ),
            ),
            Container(color: Colors.yellow, height: 90, width: 40),
          ],
        ),
      ),
    );
  }
```

### Screenshots or Video


<img width="540" height="1200" alt="Image" src="https://github.com/user-attachments/assets/680ecad7-6784-46a6-94b0-68d2315f053d" />

### Logs

_No response_

### Flutter Doctor output

```
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 3.44.4, on macOS 26.5.1 25F80 darwin-arm64, locale en-IN)
[✓] Android toolchain - develop for Android devices (Android SDK version 36.1.0)
[!] Xcode - develop for iOS and macOS
    ✗ Xcode installation is incomplete; a full installation is necessary for iOS and macOS development.
      Download at: https://developer.apple.com/xcode/
      Or install Xcode via the App Store.
      Once installed, run:
        sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
        sudo xcodebuild -runFirstLaunch
    ! CocoaPods not installed.
        CocoaPods is a package manager for iOS or macOS platform code.
        Without CocoaPods, plugins will not work on iOS or macOS.
        For more info, see https://flutter.dev/to/platform-plugins
      For installation instructions, see https://guides.cocoapods.org/using/getting-started.html#installation
[✓] Chrome - develop for the web
[✓] Connected device (2 available)
[✓] Network resources

! Doctor found issues in 1 category.
satya@Satyams-MacBook-Air test % flutter doctor -v
[✓] Flutter (Channel stable, 3.44.4, on macOS 26.5.1 25F80 darwin-arm64, locale en-IN) [70ms]
    • Flutter version 3.44.4 on channel stable at /Users/satya/main/flutter_stable/flutter
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision ad70ec4617 (8 weeks ago), 2026-06-24 11:07:06 -0700
    • Engine revision a10d8ac38d
    • Dart version 3.12.2
    • DevTools version 2.57.0
    • Feature flags: enable-web, enable-linux-desktop, enable-macos-desktop, enable-windows-desktop, enable-android, enable-ios, cli-animations,
      enable-native-assets, enable-swift-package-manager, omit-legacy-version-file, enable-lldb-debugging, enable-uiscene-migration

[✓] Android toolchain - develop for Android devices (Android SDK version 36.1.0) [605ms]
    • Android SDK at /Users/satya/Library/Android/sdk
    • Emulator version 36.6.11.0 (build_id 15507667) (CL:N/A)
    • Platform android-36.1, build-tools 36.1.0
    • Java binary at: /Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/java
      This is the JDK bundled with the latest Android Studio installation on this machine.
      To manually set the JDK path, use: `flutter config --jdk-dir="path/to/jdk"`.
    • Java version OpenJDK Runtime Environment (build 21.0.10+-117844308-b1163.108)
    • All Android licenses accepted.

[!] Xcode - develop for iOS and macOS [54ms]
    ✗ Xcode installation is incomplete; a full installation is necessary for iOS and macOS development.
      Download at: https://developer.apple.com/xcode/
      Or install Xcode via the App Store.
      Once installed, run:
        sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
        sudo xcodebuild -runFirstLaunch
    ! CocoaPods not installed.
        CocoaPods is a package manager for iOS or macOS platform code.
        Without CocoaPods, plugins will not work on iOS or macOS.
        For more info, see https://flutter.dev/to/platform-plugins
      For installation instructions, see https://guides.cocoapods.org/using/getting-started.html#installation

[✓] Chrome - develop for the web [19ms]
    • Chrome at /Applications/Google Chrome.app/Contents/MacOS/Google Chrome

[✓] Connected device (2 available) [89ms]
    • macOS (desktop) • macos  • darwin-arm64   • macOS 26.5.1 25F80 darwin-arm64
    • Chrome (web)    • chrome • web-javascript • Google Chrome 151.0.7922.138

[✓] Network resources [466ms]
    • All expected network resources are available.

! Doctor found issues in 1 category.
```


fixes #430