### PR TITLE
docs: use the dotLottie 2.0 animation path in the README decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Future<LottieComposition?> customDecoder(List<int> bytes) {
     bytes,
     filePicker: (files) {
       return files.firstWhereOrNull(
-        (f) => f.name.startsWith('animations/') && f.name.endsWith('.json'),
+        (f) => f.name.startsWith('a/') && f.name.endsWith('.json'),
       );
     },
   );


### PR DESCRIPTION
dotLottie 2.0 keeps the animation json under `a/` instead of `animations/`.

The README custom decoder example still used the 1.0 path. I pointed it at `a/` so the snippet matches the current spec.

https://dotlottie.io/spec/2.0/

Fixes #405