### PR TITLE
chore: update compatibility with Flutter 3.47

### DIFF
--- a/example/lib/bench_main.dart
+++ b/example/lib/bench_main.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:lottie/lottie.dart';
 

--- a/example/lib/examples/alert_dialog.dart
+++ b/example/lib/examples/alert_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:lottie/lottie.dart';
 

--- a/example/lib/examples/animate_no_repeat.dart
+++ b/example/lib/examples/animate_no_repeat.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() async {

--- a/example/lib/examples/animation_controller.dart
+++ b/example/lib/examples/animation_controller.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/lib/examples/animation_full_control.dart
+++ b/example/lib/examples/animation_full_control.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 /// This example show how to play the Lottie animation in various way:

--- a/example/lib/examples/blur.dart
+++ b/example/lib/examples/blur.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/lib/examples/cache.dart
+++ b/example/lib/examples/cache.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const App());

--- a/example/lib/examples/custom_draw.dart
+++ b/example/lib/examples/custom_draw.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:lottie/lottie.dart';
 

--- a/example/lib/examples/custom_load.dart
+++ b/example/lib/examples/custom_load.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/lib/examples/dotlottie.dart
+++ b/example/lib/examples/dotlottie.dart
@@ -1,5 +1,5 @@
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const App());

--- a/example/lib/examples/draw_cache.dart
+++ b/example/lib/examples/draw_cache.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
-import 'package:flutter/material.dart' hide Image;
-import 'package:flutter/material.dart' as material;
+import 'package:material_ui/material_ui.dart' hide Image;
+import 'package:material_ui/material_ui.dart' as material;
 import 'package:lottie/lottie.dart';
 
 /// This example shows how to cache the animation as a `List<Image>`.

--- a/example/lib/examples/drop_shadow.dart
+++ b/example/lib/examples/drop_shadow.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/lib/examples/dynamic_properties.dart
+++ b/example/lib/examples/dynamic_properties.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:lottie/lottie.dart';
 

--- a/example/lib/examples/dynamic_text.dart
+++ b/example/lib/examples/dynamic_text.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() async {

--- a/example/lib/examples/error_builder.dart
+++ b/example/lib/examples/error_builder.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/lib/examples/examples.dart
+++ b/example/lib/examples/examples.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/lib/examples/hide_after_complete.dart
+++ b/example/lib/examples/hide_after_complete.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() async {

--- a/example/lib/examples/markers.dart
+++ b/example/lib/examples/markers.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 /// This example shows how to play the animation between two markers.

--- a/example/lib/examples/render_cache.dart
+++ b/example/lib/examples/render_cache.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() {

--- a/example/lib/examples/repeat.dart
+++ b/example/lib/examples/repeat.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/lib/examples/run_once.dart
+++ b/example/lib/examples/run_once.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import 'package:lottie/lottie.dart';
 import '../src/all_files.g.dart';

--- a/example/lib/examples/save_frames.dart
+++ b/example/lib/examples/save_frames.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'dart:ui';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:lottie/lottie.dart';
 import 'package:path/path.dart' as p;

--- a/example/lib/examples/simple_dynamic_properties.dart
+++ b/example/lib/examples/simple_dynamic_properties.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/lib/examples/telegram_stickers.dart
+++ b/example/lib/examples/telegram_stickers.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const App());

--- a/example/lib/frame_rate_demo.dart
+++ b/example/lib/frame_rate_demo.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:lottie/lottie.dart';
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() => runApp(const MyApp());

--- a/example/lib/main_app.dart
+++ b/example/lib/main_app.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import 'package:lottie/lottie.dart';
 import 'src/all_files.g.dart';

--- a/example/lib/sizing_example.dart
+++ b/example/lib/sizing_example.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:lottie/lottie.dart';
 

--- a/example/lib/tests/airbnb.dart
+++ b/example/lib/tests/airbnb.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() async {

--- a/example/lib/tests/we_accept.dart
+++ b/example/lib/tests/we_accept.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 void main() async {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   collection:
+  cupertino_ui:
   flutter:
     sdk: flutter
   flutter_colorpicker:
@@ -18,6 +19,7 @@ dependencies:
   logging:
   lottie:
     path: ../
+  material_ui:
   path:
   path_provider:
 

--- a/lib/src/providers/lottie_provider.dart
+++ b/lib/src/providers/lottie_provider.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
 import '../../lottie.dart';
 import 'load_image.dart';

--- a/lib/src/render_cache.dart
+++ b/lib/src/render_cache.dart
@@ -1,5 +1,5 @@
 import 'dart:ui';
-import 'package:flutter/material.dart' show RenderBox;
+import 'package:material_ui/material_ui.dart' show RenderBox;
 import '../lottie.dart';
 import 'render_cache/store_drawing.dart';
 import 'render_cache/store_raster.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cupertino_ui:
+    dependency: "direct main"
+    description:
+      name: cupertino_ui
+      sha256: e9dfe7fac704028f8928cbe4028a0be5e8a709498e8daf8247de99e99a32aef3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   dart_style:
     dependency: "direct dev"
     description:
@@ -150,6 +158,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -187,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.3"
   jni:
     dependency: transitive
     description:
@@ -247,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -259,14 +280,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: "9c0156b0cf8b3f56d365c8ffe051a720be3cae9eec55119f01e01b986ffb7101"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -452,10 +481,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -468,10 +497,10 @@ packages:
     dependency: "direct main"
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -513,5 +542,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
     source: hosted
     version: "3.0.7"
   cupertino_ui:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: cupertino_ui
       sha256: e9dfe7fac704028f8928cbe4028a0be5e8a709498e8daf8247de99e99a32aef3
@@ -281,13 +281,13 @@ packages:
     source: hosted
     version: "0.13.0"
   material_ui:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: material_ui
-      sha256: "9c0156b0cf8b3f56d365c8ffe051a720be3cae9eec55119f01e01b986ffb7101"
+      sha256: fbfb53cab6c4629438feeade5f3d305f72944bc9d9f25786b19106d32b80ec45
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ funding:
   - https://github.com/sponsors/xvrh
 
 environment:
-  sdk: '^3.8.0'
-  flutter: '>=3.32.0'
+  sdk: '^3.12.0'
+  flutter: '>=3.44.0'
 
 dependencies:
   archive: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,19 +16,19 @@ environment:
 
 dependencies:
   archive: ^4.0.0
-  cupertino_ui: ^1.0.2
   flutter:
     sdk: flutter
   http: ^1.0.0
-  material_ui: ^1.1.1
   path: ^1.8.0
   vector_math: ^2.1.0
 
 dev_dependencies:
   analyzer:
+  cupertino_ui:
   dart_style:
   flutter_lints:
   flutter_test:
     sdk: flutter
+  material_ui:
   pub_semver:
   yaml:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,9 +16,11 @@ environment:
 
 dependencies:
   archive: ^4.0.0
+  cupertino_ui: ^1.0.2
   flutter:
     sdk: flutter
   http: ^1.0.0
+  material_ui: ^1.1.1
   path: ^1.8.0
   vector_math: ^2.1.0
 

--- a/test/characters_test.dart
+++ b/test/characters_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/src/utils/characters.dart';
 

--- a/test/dotlottie.dart
+++ b/test/dotlottie.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'dart:ui';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 import 'package:lottie/src/utils.dart';

--- a/test/dynamic_path_test.dart
+++ b/test/dynamic_path_test.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 

--- a/test/dynamic_properties_test.dart
+++ b/test/dynamic_properties_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'dart:ui';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 import 'utils.dart';

--- a/test/dynamic_test.dart
+++ b/test/dynamic_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'dart:ui';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 import 'utils.dart';

--- a/test/dynamic_text_properties_test.dart
+++ b/test/dynamic_text_properties_test.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 

--- a/test/dynamic_text_test.dart
+++ b/test/dynamic_text_test.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 import 'utils.dart';

--- a/test/fireworks_test.dart
+++ b/test/fireworks_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'dart:ui';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 import 'package:path/path.dart' as p;

--- a/test/golden_test.dart
+++ b/test/golden_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'dart:ui';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 import 'package:path/path.dart' as p;

--- a/test/gradient_test.dart
+++ b/test/gradient_test.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 

--- a/test/opacity_layer_test.dart
+++ b/test/opacity_layer_test.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 import 'package:path/path.dart' as p;

--- a/test/render_cache_test.dart
+++ b/test/render_cache_test.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 

--- a/test/telegram_sticker_test.dart
+++ b/test/telegram_sticker_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'dart:ui';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lottie/lottie.dart';
 import 'package:path/path.dart' as p;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:lottie/lottie.dart';
 
 class FilmStrip extends StatelessWidget {


### PR DESCRIPTION
## Description

This PR updates the package for **Flutter 3.47.1** and migrates the existing Material and Cupertino UI code to the new standalone `material_ui` and `cupertino_ui` packages.

### Changes

* Updated Flutter compatibility to **3.47**
* Migrated `package:flutter/material.dart` to `package:material_ui/material_ui.dart`
* Migrated `package:flutter/cupertino.dart` to `package:cupertino_ui/cupertino_ui.dart`
* Updated affected imports to work with the standalone UI packages

### Validation

* `flutter analyze` — **passed**

### Notes

This is a compatibility and migration update. No intentional changes have been made to the package's existing behavior or functionality.
