### PR TITLE
Fix terminal values after hold keyframes

### DIFF
--- a/lib/src/parser/keyframe_parser.dart
+++ b/lib/src/parser/keyframe_parser.dart
@@ -8,12 +8,20 @@ import 'json_utils.dart';
 import 'moshi/json_reader.dart';
 import 'value_parser.dart';
 
+class _HoldCurve extends Curve {
+  const _HoldCurve();
+
+  @override
+  double transformInternal(double t) => 0.0;
+}
+
 class KeyframeParser {
   /// Some animations get exported with insane cp values in the tens of thousands.
   /// PathInterpolator fails to create the interpolator in those cases and hangs.
   /// Clamping the cp helps prevent that.
   static const _maxCpValue = 100.0;
   static const _linearInterpolator = Curves.linear;
+  static const _holdInterpolator = _HoldCurve();
   static final _pathInterpolatorCache = <int, Curve>{};
 
   static final JsonReaderOptions _names = JsonReaderOptions.of([
@@ -94,9 +102,11 @@ class KeyframeParser {
     reader.endObject();
 
     if (hold) {
-      endValue = startValue;
-      // TODO: create a HoldInterpolator so progress changes don't invalidate.
-      interpolator = _linearInterpolator;
+      // setEndFrames() fills this from the next keyframe. The curve keeps the
+      // start value for the duration of the segment, then reaches the next
+      // value at the segment boundary.
+      endValue = null;
+      interpolator = _holdInterpolator;
     } else if (cp1 != null && cp2 != null) {
       interpolator = _interpolatorFor(cp1, cp2);
     } else {
@@ -256,9 +266,11 @@ class KeyframeParser {
     reader.endObject();
 
     if (hold) {
-      endValue = startValue;
-      // TODO: create a HoldInterpolator so progress changes don't invalidate.
-      interpolator = _linearInterpolator;
+      // setEndFrames() fills this from the next keyframe. The curve keeps the
+      // start value for the duration of the segment, then reaches the next
+      // value at the segment boundary.
+      endValue = null;
+      interpolator = _holdInterpolator;
     } else if (cp1 != null && cp2 != null) {
       interpolator = _interpolatorFor(cp1, cp2);
     } else if (xCp1 != null && yCp1 != null && xCp2 != null && yCp2 != null) {

--- a/test/hold_keyframe_test.dart
+++ b/test/hold_keyframe_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lottie/lottie.dart';
+
+void main() {
+  test('a terminal keyframe changes the value after a hold', () async {
+    expect(await _renderCenterPixel(0.25), const Color(0x00000000));
+    expect(await _renderCenterPixel(0.75), const Color(0xffff0000));
+  });
+}
+
+Future<Color> _renderCenterPixel(double progress) async {
+  var composition = LottieComposition.parseJsonBytes(
+    utf8.encode('''
+{
+  "v": "5.7.4",
+  "fr": 10,
+  "ip": 0,
+  "op": 20,
+  "w": 10,
+  "h": 10,
+  "layers": [
+    {
+      "ty": 1,
+      "ind": 1,
+      "nm": "Red solid",
+      "sw": 10,
+      "sh": 10,
+      "sc": "#ff0000",
+      "ip": 0,
+      "op": 20,
+      "st": 0,
+      "sr": 1,
+      "ks": {
+        "o": {
+          "a": 1,
+          "k": [
+            {"t": 0, "s": [0], "h": 1},
+            {"t": 10, "s": [100]}
+          ]
+        },
+        "r": {"a": 0, "k": 0},
+        "p": {"a": 0, "k": [0, 0, 0]},
+        "a": {"a": 0, "k": [0, 0, 0]},
+        "s": {"a": 0, "k": [100, 100, 100]}
+      }
+    }
+  ]
+}
+'''),
+  );
+  var drawable = LottieDrawable(composition)..setProgress(progress);
+  var recorder = PictureRecorder();
+  drawable.draw(Canvas(recorder), const Rect.fromLTWH(0, 0, 10, 10));
+  var picture = recorder.endRecording();
+  var image = await picture.toImage(10, 10);
+  var pixels = await image.toByteData();
+  var centerOffset = (5 * 10 + 5) * 4;
+  var color = Color.fromARGB(
+    pixels!.getUint8(centerOffset + 3),
+    pixels.getUint8(centerOffset),
+    pixels.getUint8(centerOffset + 1),
+    pixels.getUint8(centerOffset + 2),
+  );
+  image.dispose();
+  picture.dispose();
+  return color;
+}


### PR DESCRIPTION
Hold keyframes currently replace `endValue` with `startValue` during parsing. This prevents `KeyframesParser.setEndFrames()` from backfilling the segment's actual target from the following keyframe. When the following terminal keyframe is removed, its value is lost and the animation remains frozen at the held value.

This change introduces a hold curve that stays at progress 0 through the segment and reaches 1 at its boundary. Hold segments now retain a null `endValue` until `setEndFrames()` fills it from the next keyframe. The same behavior is applied to ordinary and multidimensional animated keyframes.

A rendering regression test verifies that an opacity property held at 0 changes to 100 at the terminal keyframe boundary.

Validation: `flutter test test/hold_keyframe_test.dart` passes.